### PR TITLE
Fix places where the Java DSL leaks into the Scala DSL

### DIFF
--- a/akka-http-caching/src/main/scala/akka/http/javadsl/server/directives/CachingDirectives.scala
+++ b/akka-http-caching/src/main/scala/akka/http/javadsl/server/directives/CachingDirectives.scala
@@ -68,7 +68,7 @@ class CachingDirectives {
    * Default settings are available via [[akka.http.caching.javadsl.CachingSettings.create]].
    */
   def routeCache[K](settings: CachingSettings): Cache[K, RouteResult] =
-    JavaMapping.toJava(D.routeCache[K](settings))
+    LfuCache.create[K, RouteResult](settings)
 }
 
 object CachingDirectives extends CachingDirectives

--- a/akka-http-caching/src/main/scala/akka/http/scaladsl/server/directives/CachingDirectives.scala
+++ b/akka-http-caching/src/main/scala/akka/http/scaladsl/server/directives/CachingDirectives.scala
@@ -6,8 +6,7 @@ package akka.http.scaladsl.server.directives
 
 import akka.actor.ActorSystem
 import akka.annotation.ApiMayChange
-import akka.http.caching.scaladsl.{ Cache, CachingSettingsImpl }
-import akka.http.caching.javadsl.{ CachingSettings }
+import akka.http.caching.scaladsl.{ Cache, CachingSettings }
 import akka.http.caching.LfuCache
 import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server._
@@ -54,15 +53,14 @@ trait CachingDirectives {
   }
 
   /**
-   * Creates an [[LfuCache]] with default settings obtained from the systems' configuration
+   * Creates an [[LfuCache]] with default settings obtained from the system's configuration.
    */
   @ApiMayChange // since perhaps we indeed have to hardcode the defaults in code rather than reference.conf?
   def routeCache[K](implicit s: ActorSystem): Cache[K, RouteResult] =
-    LfuCache[K, RouteResult](akka.http.caching.scaladsl.CachingSettings(s))
+    LfuCache[K, RouteResult](s)
 
   /**
    * Creates an [[LfuCache]].
-   * Default settings are available via [[akka.http.caching.scaladsl.CachingSettings.apply]].
    */
   def routeCache[K](settings: CachingSettings): Cache[K, RouteResult] =
     LfuCache[K, RouteResult](settings)

--- a/akka-http-caching/src/test/scala/akka/http/scaladsl/server/directives/CachingDirectivesSpec.scala
+++ b/akka-http-caching/src/test/scala/akka/http/scaladsl/server/directives/CachingDirectivesSpec.scala
@@ -40,7 +40,7 @@ class CachingDirectivesSpec extends WordSpec with Matchers with ScalatestRouteTe
     }
   }
 
-  "the cacheResults directive" should {
+  "the cache directive" should {
     "return and cache the response of the first GET" in {
       Get() ~> countingService ~> check { responseAs[String] shouldEqual "1" }
     }


### PR DESCRIPTION
For example apply methods should always take the Scala DSL instance
where as create methods should take the Java DSL instances.